### PR TITLE
Added ability to export the currently returned records to csv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7714,8 +7714,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -9935,6 +9934,11 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "papaparse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.2.0.tgz",
+      "integrity": "sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA=="
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -15024,8 +15028,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -15049,7 +15052,6 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15062,8 +15064,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -15072,8 +15073,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -15176,8 +15176,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -15187,7 +15186,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -15200,20 +15198,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -15230,7 +15225,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -15286,8 +15280,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -15312,8 +15305,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -15323,7 +15315,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -15392,8 +15383,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -15423,7 +15413,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15441,7 +15430,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -15480,13 +15468,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "leaflet": "^1.6.0",
     "lodash": "4.17.15",
     "node-sass": "^4.13.1",
+    "papaparse": "5.2.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/components/ExportControl/index.js
+++ b/src/components/ExportControl/index.js
@@ -13,7 +13,7 @@ const ExportControl = ({data}) => {
     hiddenElement.download = 'export.csv';
     document.body.appendChild(hiddenElement);
     hiddenElement.click();
-    document.removeChild(hiddenElement);
+    document.body.removeChild(hiddenElement);
   }
   return (
     <Button variant="outlined"

--- a/src/components/ExportControl/index.js
+++ b/src/components/ExportControl/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Papa from 'papaparse';
+
+import Button from '@material-ui/core/Button';
+
+const ExportControl = ({data}) => {
+  function createCSV() {
+    const csvString = Papa.unparse(data);
+    const csvBlob = new Blob([csvString], { type: 'text/csv' });
+    const csvUrl = URL.createObjectURL(csvBlob);
+    const hiddenElement = document.createElement('a');
+    hiddenElement.href = csvUrl
+    hiddenElement.download = 'export.csv';
+    document.body.appendChild(hiddenElement);
+    hiddenElement.click();
+    document.removeChild(hiddenElement);
+  }
+  return (
+    <Button variant="outlined"
+      onClick={createCSV}
+      size="small">
+      Export Records
+    </Button>
+  );
+};
+
+export default ExportControl;

--- a/src/containers/DataPage/index.js
+++ b/src/containers/DataPage/index.js
@@ -1,27 +1,28 @@
-import React, {useContext, useEffect, useState} from "react";
+import React, {useContext, useEffect, useState} from 'react';
 
 import MapIcon from '@material-ui/icons/Map';
 import TocIcon from '@material-ui/icons/Toc';
-import Tab from "@material-ui/core/Tab";
-import Tabs from "@material-ui/core/Tabs";
-import { useQuery } from "urql";
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import { useQuery } from 'urql';
 
-import DataTable from "../../components/DataTable";
-import DataMap from "../../components/DataMap";
-import SearchBar from "../../components/SearchBar";
-import * as queries from "../../data/queries";
+import DataTable from '../../components/DataTable';
+import DataMap from '../../components/DataMap';
+import SearchBar from '../../components/SearchBar';
+import ExportControl from '../../components/ExportControl';
+import * as queries from '../../data/queries';
 
-import "./DataPage.scss";
-import {useAuth0} from "../../auth/react-auth0-spa";
-import {RoleContext} from "../App";
+import './DataPage.scss';
+import {useAuth0} from '../../auth/react-auth0-spa';
+import {RoleContext} from '../App';
 import {
   ROLES,
   MAX_QUERY_SIZE
-} from "../../config";
-import searchQueryDataDisplayAdapter from "../../data/searchQueryDataDisplayAdapter";
+} from '../../config';
+import searchQueryDataDisplayAdapter from '../../data/searchQueryDataDisplayAdapter';
 import TabPanel from './TabPanel';
-import Typography from "@material-ui/core/Typography";
-import Box from "@material-ui/core/Box";
 
 const DataPage = () => {
   const { isAuthenticated } = useAuth0();
@@ -38,7 +39,7 @@ const DataPage = () => {
       limit: MAX_QUERY_SIZE,
       distance: searchDistance, // in meters
       point: {
-        type: "Point",
+        type: 'Point',
         coordinates: [searchCoords.lng, searchCoords.lat]
       },
       scale: (scaleFilter && scaleFilter.value.split(',')) || ['Small', 'Medium', 'Large']
@@ -71,6 +72,7 @@ const DataPage = () => {
         scaleFilter={scaleFilter}
         setScaleFilter={setScaleFilter}
       />
+      <ExportControl data={rowsData} />
 
       <Tabs
         value={tabIdx}


### PR DESCRIPTION
Used papaparse to avoid weird edge cases with csv escaping.

Currently this will export all records loaded into memory. As the user adds search criteria this list should reduce.

If this is too cumbersome then it would be straightforward to add some check boxes for the user to "select" the records to export.